### PR TITLE
fix: 打刻申請ボタンのクリック処理を修正

### DIFF
--- a/src/timecard-apply.ts
+++ b/src/timecard-apply.ts
@@ -84,12 +84,20 @@ async function applyTimecard() {
             // Find and click the initial application button
             console.log('Looking for initial application button...');
             const buttons = await page.$$('input[type="button"]');
+            let buttonClicked = false;
             for (const button of buttons) {
               const buttonId = await button.getAttribute('id');
               if (buttonId && buttonId.startsWith('button_') && !buttonId.includes('schedule')) {
-                console.log('Found button, clicking...');
+                console.log(`Found button with id: ${buttonId}, clicking...`);
+                await button.click();
+                buttonClicked = true;
                 break;
               }
+            }
+            
+            if (!buttonClicked) {
+              console.log('Could not find application button, skipping row');
+              continue;
             }
 
             // Wait for the form to appear


### PR DESCRIPTION
## Summary
- 打刻申請ボタンが実際にクリックされていなかった問題を修正
- ボタンが見つからない場合のエラーハンドリングを追加

## Changes
- `await button.click()` を追加して、ボタンを見つけた後に実際にクリックするように修正
- `buttonClicked` フラグを追加してクリック成功を追跡
- ボタンが見つからない場合は `continue` で次の行の処理にスキップ

## Technical Details
以前のコードでは、ボタンを見つけた後 `break` するだけでクリック処理が実行されていませんでした。
この修正により、打刻申請フォームが正しく開くようになります。

## Test plan
- [ ] King of Timeにログイン
- [ ] エラー勤務がある場合、自動的に打刻申請が実行されることを確認
- [ ] 申請ボタンがクリックされ、フォームが表示されることを確認